### PR TITLE
fix SetCurrentCustomStateKey parameter

### DIFF
--- a/src/Xamarin.Forms.StateSquid.Multi/Platforms/Shared/StateLayout.cs
+++ b/src/Xamarin.Forms.StateSquid.Multi/Platforms/Shared/StateLayout.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.StateSquid
             return (State)b.GetValue(CurrentStateProperty);
         }
 
-        public static void SetCurrentCustomStateKey(BindableObject b, State value)
+        public static void SetCurrentCustomStateKey(BindableObject b, string value)
         {
             b.SetValue(CurrentCustomStateKeyProperty, value);
         }


### PR DESCRIPTION
The SetCurrentCustomStateKey method had an Enum type parameter instead of a string